### PR TITLE
Add error recovery when UDP transfer fails

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -201,4 +201,9 @@ void NTPClient::sendNTPPacket() {
   }
   this->_udp->write(this->_packetBuffer, NTP_PACKET_SIZE);
   this->_udp->endPacket();
+  if (this->_udp->endPacket() == 0) {
+    // recovery if UDP client encounters any errors
+    this->end();
+    this->begin(this->_port);
+  }
 }


### PR DESCRIPTION
This commit does not affect normal case. Even if UDP transfer fails for
any reasons in sendNTPPacket, it can be recovered by re-initialization.